### PR TITLE
スタッフ情報-編集画面の追加

### DIFF
--- a/components/atoms/ARoundImg.vue
+++ b/components/atoms/ARoundImg.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="h-[120px] flex justify-between items-end md:justify-start">
-    <img src="https://placehold.jp/150x150.png" alt="" class=" w-[120px] h-[120px] bg-gray-lighter rounded-full">
+    <img src="https://placehold.jp/150x150.png" alt="" class=" w-[120px] h-[120px] bg-gray-lighter rounded-full" />
     <label for="upImg" class="text-sm text-orange md:ml-6">画像をアップロードする</label>
-    <input id="upImg" type="file">
+    <input id="upImg" type="file" />
   </div>
 </template>
 

--- a/components/organisms/ODistrict.vue
+++ b/components/organisms/ODistrict.vue
@@ -2,7 +2,7 @@
   <div>
     <ul class="mt-5">
       <li
-        v-for="(district,i) in districts"
+        v-for="(district, i) in districts"
         :key="i"
         class="
           md:w-[220px]
@@ -10,8 +10,10 @@
           h-[40px]
           flex
           items-center
-          border-b border-gray-lighter
           m-auto
+          border-b
+        border-gray-lighter
+        text-gray-dark
         "
       >
         <label class="myCheckbox">
@@ -22,7 +24,7 @@
             type="checkbox"
             :value="district.name"
             @change="addList(district.name)"
-          ><span class="myCheckbox-DummyInput" />
+          /><span class="myCheckbox-DummyInput" />
           <span class="myCheckbox-LabelText">{{
             district.name
           }}</span>
@@ -163,9 +165,8 @@ const districts = [
   }
 
   .myCheckbox-LabelText {
-  margin-left: 12px;
-  display: block;
+    margin-left: 12px;
+    display: block;
+  }
 }
-}
-
 </style>

--- a/components/organisms/OPrefecture.vue
+++ b/components/organisms/OPrefecture.vue
@@ -9,14 +9,16 @@
         h-[40px]
         flex
         items-center
+        justify-between
         space-x-3
-        border-b border-gray-lighter
+        m-auto
+        py-[11px]
+        border-b
+      border-gray-lighter
         last:border-b-transparent
         md:last:border-b-gray-lighter
-        m-auto
-        justify-between
         text-sm
-        py-[11px]
+      text-gray-dark
       "
     >
       {{ prefecture.name }}

--- a/openapi.json
+++ b/openapi.json
@@ -1183,18 +1183,25 @@
                     "type": "string",
                     "example": "password",
                     "description": "パスワード"
+                  },
+                  "type": {
+                    "type": "string",
+                    "example": "Client",
+                    "description": "ユーザーの種別"
                   }
                 },
                 "required": [
                   "email",
-                  "password"
+                  "password",
+                  "type"
                 ]
               },
               "examples": {
                 "example-1": {
                   "value": {
                     "email": "test1@example.com",
-                    "password": "password"
+                    "password": "password",
+                    "type": "Client"
                   }
                 }
               }
@@ -2029,7 +2036,7 @@
         }
       ]
     },
-    "/api/v1/manager/office/{id}": {
+    "/api/v1/manager/office": {
       "get": {
         "summary": "事業所詳細取得(ケアマネ)",
         "tags": [
@@ -2037,40 +2044,613 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "id": 1,
+                      "manager_id": 5,
+                      "name": "ホームケア事務所_1",
+                      "feature_title": "事業所紹介タイトル",
+                      "feature_detail": "ここに事業所の特徴テキストが入ります",
+                      "workday": [
+                        "mon"
+                      ],
+                      "workday_detail": "営業日時についてのテキストが入ります",
+                      "lat": "43.073211",
+                      "lng": "141.350427",
+                      "fax": "111-2222-3333",
+                      "nearest_station": "北12条駅 徒歩5分",
+                      "created_at": "2022-10-29T00:47:31.090+09:00",
+                      "updated_at": "2022-10-29T00:47:31.090+09:00"
+                    }
+                  },
+                  "title": "Office",
+                  "description": "事業所",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "manager_id": {
+                      "type": "integer",
+                      "example": 5
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "ホームケア事務所_1"
+                    },
+                    "feature_title": {
+                      "type": "string",
+                      "example": "事業所紹介タイトル"
+                    },
+                    "feature_detail": {
+                      "type": "string",
+                      "example": "ここに事業所の特徴テキストが入ります"
+                    },
+                    "workday": {
+                      "type": "array",
+                      "example": [
+                        "mon"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "workday_detail": {
+                      "type": "string",
+                      "example": "営業日時についてのテキストが入ります"
+                    },
+                    "lat": {
+                      "type": "string",
+                      "example": "43.073211"
+                    },
+                    "lng": {
+                      "type": "string",
+                      "example": "41.350427"
+                    },
+                    "fax": {
+                      "type": "string",
+                      "example": "111-2222-3333"
+                    },
+                    "nearest_station": {
+                      "type": "string",
+                      "example": "北12条駅 徒歩5分"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "manager_id",
+                    "name",
+                    "feature_title",
+                    "feature_detail",
+                    "workday",
+                    "workday_detail",
+                    "lat",
+                    "lng",
+                    "fax",
+                    "nearest_station"
+                  ]
+                },
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "id": 1,
+                      "manager_id": 5,
+                      "name": "ホームケア事務所_1",
+                      "feature_title": "事業所紹介タイトル",
+                      "feature_detail": "ここに事業所の特徴テキストが入ります",
+                      "workday": [
+                        "mon"
+                      ],
+                      "workday_detail": "営業日時についてのテキストが入ります",
+                      "lat": "43.073211",
+                      "lng": "41.350427",
+                      "fax": "111-2222-3333",
+                      "nearest_station": "北12条駅 徒歩5分",
+                      "created_at": "string",
+                      "updated_at": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getManagerOffice",
-        "description": "単一の事務所の詳細を取得する"
+        "description": "Manager自身の事務所詳細を取得する"
       },
-      "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "example": 1,
-            "format": "int64"
-          },
-          "description": "対象のid"
-        }
-      ],
+      "parameters": [],
       "patch": {
         "summary": "事業所更新(ケアマネ)",
         "operationId": "updateManagerOffice",
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "id": 1,
+                      "manager_id": 5,
+                      "name": "ホームケア事務所_1",
+                      "feature_title": "事業所紹介タイトル",
+                      "feature_detail": "ここに事業所の特徴テキストが入ります",
+                      "workday": [
+                        "mon"
+                      ],
+                      "workday_detail": "営業日時についてのテキストが入ります",
+                      "lat": "43.073211",
+                      "lng": "141.350427",
+                      "fax": "111-2222-3333",
+                      "nearest_station": "北12条駅 徒歩5分",
+                      "created_at": "2022-10-29T00:47:31.090+09:00",
+                      "updated_at": "2022-10-29T00:47:31.090+09:00"
+                    }
+                  },
+                  "title": "Office",
+                  "description": "事業所",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "manager_id": {
+                      "type": "integer",
+                      "example": 5
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "ホームケア事務所_1"
+                    },
+                    "feature_title": {
+                      "type": "string",
+                      "example": "事業所紹介タイトル"
+                    },
+                    "feature_detail": {
+                      "type": "string",
+                      "example": "ここに事業所の特徴テキストが入ります"
+                    },
+                    "workday": {
+                      "type": "array",
+                      "example": [
+                        "mon"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "workday_detail": {
+                      "type": "string",
+                      "example": "営業日時についてのテキストが入ります"
+                    },
+                    "lat": {
+                      "type": "string",
+                      "example": "43.073211"
+                    },
+                    "lng": {
+                      "type": "string",
+                      "example": "41.350427"
+                    },
+                    "fax": {
+                      "type": "string",
+                      "example": "111-2222-3333"
+                    },
+                    "nearest_station": {
+                      "type": "string",
+                      "example": "北12条駅 徒歩5分"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "manager_id",
+                    "name",
+                    "feature_title",
+                    "feature_detail",
+                    "workday",
+                    "workday_detail",
+                    "lat",
+                    "lng",
+                    "fax",
+                    "nearest_station"
+                  ]
+                },
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "id": 1,
+                      "manager_id": 5,
+                      "name": "ホームケア事務所_1",
+                      "feature_title": "事業所紹介タイトル",
+                      "feature_detail": "ここに事業所の特徴テキストが入ります",
+                      "workday": [
+                        "mon"
+                      ],
+                      "workday_detail": "営業日時についてのテキストが入ります",
+                      "lat": "43.073211",
+                      "lng": "41.350427",
+                      "fax": "111-2222-3333",
+                      "nearest_station": "北12条駅 徒歩5分",
+                      "created_at": "string",
+                      "updated_at": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
           "office"
         ],
-        "description": "単一の事務所を更新する"
+        "description": "Manager自身の事務所を更新する"
       }
     },
-    "/api/v1/client/appointments": {
+    "/api/v1/manager/office_overview": {
+      "parameters": [],
+      "patch": {
+        "summary": "施設概要更新(ケアマネ)",
+        "operationId": "updateManagerOfficeOverview",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "id": 3,
+                      "office_id": 56,
+                      "classify": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）",
+                      "opening_date": "2022-03-11",
+                      "room_count": 30,
+                      "requirements": "満60歳以上の方、入居時自立・要支援・要介護",
+                      "shared_facilities": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園",
+                      "business_entity": "株式会社ユニマット　リタイアメント・コミュニティ",
+                      "official_site_url": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                      "created_at": "2022-10-29T18:22:43.829+09:00",
+                      "updated_at": "2022-10-29T18:22:43.829+09:00"
+                    }
+                  },
+                  "title": "OfficeOverview",
+                  "description": "施設概要",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "主キー",
+                      "example": 1
+                    },
+                    "office_id": {
+                      "type": "integer",
+                      "description": "事業所外部キー",
+                      "example": 3
+                    },
+                    "classify": {
+                      "type": "string",
+                      "description": "類型",
+                      "example": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）"
+                    },
+                    "opening_date": {
+                      "type": "string",
+                      "description": "開設年月",
+                      "example": "2022-03-11",
+                      "format": "date"
+                    },
+                    "room_count": {
+                      "type": "integer",
+                      "description": "居室数",
+                      "example": 30
+                    },
+                    "requirements": {
+                      "type": "string",
+                      "description": "入居時の要件",
+                      "example": "満60歳以上の方、入居時自立・要支援・要介護"
+                    },
+                    "shared_facilities": {
+                      "type": "string",
+                      "description": "共用設備",
+                      "example": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園"
+                    },
+                    "business_entity": {
+                      "type": "string",
+                      "description": "経営・事業主体",
+                      "example": "株式会社ユニマット　リタイアメント・コミュニティ"
+                    },
+                    "official_site_url": {
+                      "type": "string",
+                      "description": "公式サイトのURL",
+                      "example": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                      "format": "uri"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "example": "2022-10-29T18:22:43.829+09:00"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2022-10-29T18:22:43.829+09:00"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "office_id",
+                    "classify",
+                    "opening_date",
+                    "room_count",
+                    "requirements",
+                    "shared_facilities",
+                    "business_entity",
+                    "official_site_url",
+                    "created_at",
+                    "updated_at"
+                  ]
+                },
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "id": 1,
+                      "office_id": 3,
+                      "classify": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）",
+                      "opening_date": "2022-03-11",
+                      "room_count": 30,
+                      "requirements": "満60歳以上の方、入居時自立・要支援・要介護",
+                      "shared_facilities": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園",
+                      "business_entity": "株式会社ユニマット　リタイアメント・コミュニティ",
+                      "official_site_url": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                      "created_at": "2022-10-29T18:22:43.829+09:00",
+                      "updated_at": "2022-10-29T18:22:43.829+09:00"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "バリデーションチェック失敗時。status: :bad_requestで返ってくるときの値。",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "description": "エラーの値",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "類型は200文字以内で入力してください"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Manager自身の施設概要を更新する",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "classify": {
+                    "type": "string",
+                    "description": "類型",
+                    "example": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）"
+                  },
+                  "opening_date": {
+                    "type": "string",
+                    "description": "開設年月",
+                    "example": "2022-03-11",
+                    "format": "date"
+                  },
+                  "room_count": {
+                    "type": "integer",
+                    "description": "居室数",
+                    "example": 30
+                  },
+                  "requirements": {
+                    "type": "string",
+                    "description": "入居時の要件",
+                    "example": "満60歳以上の方、入居時自立・要支援・要介護"
+                  },
+                  "shared_facilities": {
+                    "type": "string",
+                    "description": "共用設備",
+                    "example": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園"
+                  },
+                  "business_entity": {
+                    "type": "string",
+                    "description": "経営・事業主体",
+                    "example": "株式会社ユニマット　リタイアメント・コミュニティ"
+                  },
+                  "official_site_url": {
+                    "type": "string",
+                    "description": "公式サイトのURL",
+                    "example": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "classify",
+                  "opening_date",
+                  "room_count",
+                  "requirements",
+                  "shared_facilities",
+                  "business_entity",
+                  "official_site_url"
+                ]
+              },
+              "examples": {
+                "example-1": {
+                  "value": {
+                    "classify": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）",
+                    "opening_date": "2022-03-11",
+                    "room_count": 30,
+                    "requirements": "満60歳以上の方、入居時自立・要支援・要介護",
+                    "shared_facilities": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園",
+                    "business_entity": "株式会社ユニマット　リタイアメント・コミュニティ",
+                    "official_site_url": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html"
+                  }
+                }
+              }
+            }
+          },
+          "description": ""
+        },
+        "tags": [
+          "office_overview"
+        ]
+      },
+      "get": {
+        "summary": "施設概要取得（ケアマネ）",
+        "operationId": "getManagerOfficeOverview",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "id": 3,
+                      "office_id": 56,
+                      "classify": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）",
+                      "opening_date": "2022-03-11",
+                      "room_count": 30,
+                      "requirements": "満60歳以上の方、入居時自立・要支援・要介護",
+                      "shared_facilities": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園",
+                      "business_entity": "株式会社ユニマット　リタイアメント・コミュニティ",
+                      "official_site_url": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                      "created_at": "2022-10-29T18:22:43.829+09:00",
+                      "updated_at": "2022-10-29T18:22:43.829+09:00"
+                    }
+                  },
+                  "title": "OfficeOverview",
+                  "description": "施設概要",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "主キー",
+                      "example": 1
+                    },
+                    "office_id": {
+                      "type": "integer",
+                      "description": "事業所外部キー",
+                      "example": 3
+                    },
+                    "classify": {
+                      "type": "string",
+                      "description": "類型",
+                      "example": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）"
+                    },
+                    "opening_date": {
+                      "type": "string",
+                      "description": "開設年月",
+                      "example": "2022-03-11",
+                      "format": "date"
+                    },
+                    "room_count": {
+                      "type": "integer",
+                      "description": "居室数",
+                      "example": 30
+                    },
+                    "requirements": {
+                      "type": "string",
+                      "description": "入居時の要件",
+                      "example": "満60歳以上の方、入居時自立・要支援・要介護"
+                    },
+                    "shared_facilities": {
+                      "type": "string",
+                      "description": "共用設備",
+                      "example": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園"
+                    },
+                    "business_entity": {
+                      "type": "string",
+                      "description": "経営・事業主体",
+                      "example": "株式会社ユニマット　リタイアメント・コミュニティ"
+                    },
+                    "official_site_url": {
+                      "type": "string",
+                      "description": "公式サイトのURL",
+                      "example": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                      "format": "uri"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "example": "2022-10-29T18:22:43.829+09:00"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2022-10-29T18:22:43.829+09:00"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "office_id",
+                    "classify",
+                    "opening_date",
+                    "room_count",
+                    "requirements",
+                    "shared_facilities",
+                    "business_entity",
+                    "official_site_url",
+                    "created_at",
+                    "updated_at"
+                  ]
+                },
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "id": 1,
+                      "office_id": 3,
+                      "classify": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）",
+                      "opening_date": "2022-03-11",
+                      "room_count": 30,
+                      "requirements": "満60歳以上の方、入居時自立・要支援・要介護",
+                      "shared_facilities": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園",
+                      "business_entity": "株式会社ユニマット　リタイアメント・コミュニティ",
+                      "official_site_url": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+                      "created_at": "2022-10-29T18:22:43.829+09:00",
+                      "updated_at": "2022-10-29T18:22:43.829+09:00"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Manager自身の施設概要を取得する",
+        "tags": [
+          "office_overview"
+        ]
+      }
+    },
+    "/api/v1/client/reserves": {
       "post": {
         "summary": "予約作成(事業所利用者)",
         "operationId": "createClientAppointment",
@@ -2086,7 +2666,7 @@
       },
       "get": {
         "summary": "予約一覧取得(事業所利用者)",
-        "operationId": "getClientAppointments",
+        "operationId": "getClientReserves",
         "responses": {
           "200": {
             "description": "OK"
@@ -2099,10 +2679,10 @@
       },
       "parameters": []
     },
-    "/api/v1/manager/appointments": {
+    "/api/v1/manager/reserves": {
       "get": {
         "summary": "予約一覧取得(ケアマネ)",
-        "operationId": "getManagerAppointments",
+        "operationId": "getManagerReserves",
         "responses": {
           "200": {
             "description": "OK"
@@ -2115,7 +2695,7 @@
       },
       "parameters": []
     },
-    "/api/v1/manager/appointment/{id}": {
+    "/api/v1/manager/reserve/{id}": {
       "parameters": [
         {
           "name": "id",
@@ -2131,7 +2711,7 @@
       ],
       "patch": {
         "summary": "予約更新(ケアマネ)",
-        "operationId": "updateManagerAppointment",
+        "operationId": "updateManagerReserve",
         "responses": {
           "200": {
             "description": "OK"
@@ -2580,6 +3160,222 @@
           "uid",
           "allow_password_change"
         ]
+      },
+      "Office": {
+        "type": "object",
+        "x-examples": {
+          "Example 1": {
+            "id": 1,
+            "manager_id": 5,
+            "name": "ホームケア事務所_1",
+            "feature_title": "事業所紹介タイトル",
+            "feature_detail": "ここに事業所の特徴テキストが入ります",
+            "workday": [
+              "mon"
+            ],
+            "workday_detail": "営業日時についてのテキストが入ります",
+            "lat": "43.073211",
+            "lng": "141.350427",
+            "fax": "111-2222-3333",
+            "nearest_station": "北12条駅 徒歩5分",
+            "created_at": "2022-10-29T00:47:31.090+09:00",
+            "updated_at": "2022-10-29T00:47:31.090+09:00"
+          }
+        },
+        "title": "Office",
+        "description": "事業所",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1
+          },
+          "manager_id": {
+            "type": "integer",
+            "example": 5
+          },
+          "name": {
+            "type": "string",
+            "example": "ホームケア事務所_1"
+          },
+          "feature_title": {
+            "type": "string",
+            "example": "事業所紹介タイトル"
+          },
+          "feature_detail": {
+            "type": "string",
+            "example": "ここに事業所の特徴テキストが入ります"
+          },
+          "workday": {
+            "type": "array",
+            "example": [
+              "mon"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "workday_detail": {
+            "type": "string",
+            "example": "営業日時についてのテキストが入ります"
+          },
+          "lat": {
+            "type": "string",
+            "example": "43.073211"
+          },
+          "lng": {
+            "type": "string",
+            "example": "41.350427"
+          },
+          "fax": {
+            "type": "string",
+            "example": "111-2222-3333"
+          },
+          "nearest_station": {
+            "type": "string",
+            "example": "北12条駅 徒歩5分"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "manager_id",
+          "name",
+          "feature_title",
+          "feature_detail",
+          "workday",
+          "workday_detail",
+          "lat",
+          "lng",
+          "fax",
+          "nearest_station"
+        ]
+      },
+      "OfficeOverview": {
+        "type": "object",
+        "x-examples": {
+          "Example 1": {
+            "id": 3,
+            "office_id": 56,
+            "classify": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）",
+            "opening_date": "2022-03-11",
+            "room_count": 30,
+            "requirements": "満60歳以上の方、入居時自立・要支援・要介護",
+            "shared_facilities": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園",
+            "business_entity": "株式会社ユニマット　リタイアメント・コミュニティ",
+            "official_site_url": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+            "created_at": "2022-10-29T18:22:43.829+09:00",
+            "updated_at": "2022-10-29T18:22:43.829+09:00"
+          }
+        },
+        "title": "OfficeOverview",
+        "description": "施設概要",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "主キー",
+            "example": 1
+          },
+          "office_id": {
+            "type": "integer",
+            "description": "事業所外部キー",
+            "example": 3
+          },
+          "classify": {
+            "type": "string",
+            "description": "類型",
+            "example": "介護付きホーム（サービス付き高齢者向け住宅　特定施設）"
+          },
+          "opening_date": {
+            "type": "string",
+            "description": "開設年月",
+            "example": "2022-03-11",
+            "format": "date"
+          },
+          "room_count": {
+            "type": "integer",
+            "description": "居室数",
+            "example": 30
+          },
+          "requirements": {
+            "type": "string",
+            "description": "入居時の要件",
+            "example": "満60歳以上の方、入居時自立・要支援・要介護"
+          },
+          "shared_facilities": {
+            "type": "string",
+            "description": "共用設備",
+            "example": "エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園"
+          },
+          "business_entity": {
+            "type": "string",
+            "description": "経営・事業主体",
+            "example": "株式会社ユニマット　リタイアメント・コミュニティ"
+          },
+          "official_site_url": {
+            "type": "string",
+            "description": "公式サイトのURL",
+            "example": "https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html",
+            "format": "uri"
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2022-10-29T18:22:43.829+09:00"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2022-10-29T18:22:43.829+09:00"
+          }
+        },
+        "required": [
+          "id",
+          "office_id",
+          "classify",
+          "opening_date",
+          "room_count",
+          "requirements",
+          "shared_facilities",
+          "business_entity",
+          "official_site_url",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "OfficeImage": {
+        "title": "OfficeImage",
+        "x-stoplight": {
+          "id": "6vrskiww5y6eu"
+        },
+        "type": "object",
+        "description": "事業所画像",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1,
+            "description": "主キー"
+          },
+          "office_id": {
+            "type": "integer",
+            "example": 1,
+            "description": "事業所id"
+          },
+          "caption": {
+            "type": "string",
+            "example": "画像の説明テキストが入ります",
+            "description": "画像の見出しテキスト"
+          },
+          "role": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "office_id"
+        ]
       }
     },
     "responses": {
@@ -2757,6 +3553,31 @@
             "description": "トークン認証に必要なヘッダー(4/4)"
           }
         }
+      },
+      "BadRequest": {
+        "description": "バリデーションチェック失敗時。status: :bad_requestで返ってくるときの値。",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "errors": {
+                  "type": "array",
+                  "description": "エラーの値",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "類型は200文字以内で入力してください"
+                  ]
+                }
+              },
+              "required": [
+                "errors"
+              ]
+            }
+          }
+        }
       }
     },
     "requestBodies": {},
@@ -2824,6 +3645,10 @@
     {
       "name": "office_client",
       "description": "事業所で管理しているクライアント"
+    },
+    {
+      "name": "office_overview",
+      "description": "施設概要"
     },
     {
       "name": "staff",

--- a/pages/manager/auth/staffs/edit.vue
+++ b/pages/manager/auth/staffs/edit.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="md:w-[750px] md:mt-[73px] md:mb-20 m-auto">
+    <NuxtLink to="/" :class="`text-sm text-orange hidden md:inline-block`">
+      <ALeftArrow class="text-orange" />スタッフ情報一覧にもどる
+    </NuxtLink>
+    <div class="w-full md:w-[750px] h-full m-auto bg-white md:rounded md:shadow-sm">
+      <div class="w-[343px] md:w-[718px] m-auto mt-2">
+        <ATitle ttl-text="スタッフ情報編集" class="pt-4 pb-6" />
+        <ARoundImg />
+
+        <form class="pt-6">
+          <AInput
+            label-for="inputNm"
+            label-text="スタッフ名"
+            input-type="text"
+            placeholder="田中 太郎"
+            :required="true"
+            class="mb-6"
+          />
+
+          <AInput
+            label-for="inputNm"
+            label-text="スタッフ名(ふりがな)"
+            input-type="text"
+            placeholder="たなか たろう"
+            :required="true"
+            class="mb-6"
+          />
+
+          <ATextArea
+            label-for="inputNm"
+            label-text="スタッフ紹介文"
+            placeholder="スタッフ説明テキストが入りますスタッフ説明テキストが入ります"
+            :required="true"
+          />
+          <AButtonSubmit inner-text="変更する" user-type="manager" class="py-3 sm:py-4 mt-8" />
+          <div class="text-center mt-2 pb-8">
+            <NuxtLink to="/" :class="`text-sm text-orange`">
+              もどる
+            </NuxtLink>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/pages/manager/auth/staffs/new.vue
+++ b/pages/manager/auth/staffs/new.vue
@@ -35,14 +35,14 @@
           />
 
           <label class="myCheckbox mt-6">
-            <input class="myCheckbox-Input" type="checkbox"><span class="myCheckbox-DummyInput" />
+            <input class="myCheckbox-Input" type="checkbox" /><span class="myCheckbox-DummyInput" />
             <span class="myCheckbox-LabelText">ケアマネージャー</span>
           </label>
           <label class="myCheckbox">
-            <input class="myCheckbox-Input" type="checkbox"><span class="myCheckbox-DummyInput" />
+            <input class="myCheckbox-Input" type="checkbox" /><span class="myCheckbox-DummyInput" />
             <span class="myCheckbox-LabelText">一般スタッフ</span>
           </label>
-          <AButtonSubmit inner-text="変更する" user-type="manager" class="py-3 sm:py-4 mt-8" />
+          <AButtonSubmit inner-text="追加する" user-type="manager" class="py-3 sm:py-4 mt-8" />
           <div class="text-center mt-2 pb-8">
             <NuxtLink to="/" :class="`text-sm text-orange`">
               もどる


### PR DESCRIPTION
ケアマネージャー側の画面であるスタッフ情報編集画面の実装が完了しました。
また、実装時に以下の修正が必要なのが判明したため、併せて修正しました。

・スタッフ追加画面の「変更する」ボタンを「追加する」ボタンに修正
・TOP画面の県名と区名検索部分のフォントカラーにデザインが当たっていなかったので修正(ファイルで言うとcomponents/organisms/ODistrict.vueとcomponents/organisms/OPrefecture.vueにあたる部分です)

ご確認よろしくお願いいたします。
<img width="291" alt="スクリーンショット 2022-11-01 20 32 46" src="https://user-images.githubusercontent.com/70462212/199227758-3a8c5bd4-bace-484e-a65f-8614c3bf037a.png">
<img width="1019" alt="スクリーンショット 2022-11-01 20 32 26" src="https://user-images.githubusercontent.com/70462212/199227785-5fcba7b3-d5de-4310-8c1f-6925a479933d.png">

