### PR TITLE
予約状況確認画面の追加

### DIFF
--- a/components/organisms/OReserveCard.vue
+++ b/components/organisms/OReserveCard.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="w-full h-[262px] mb-6 bg-white rounded">
+    <div class="w-[331px] m-auto">
+      <div class="flex justify-between pt-3">
+        <span
+          class="h-[23px] px-1.5 py-0.5 text-[13px] text-pink bg-babypink font-bold rounded-sm"
+          :class="textColor"
+        >{{ contact }}</span>
+        <span class="text-[10px] text-gray-base">2020年12月31日&nbsp;19:47</span>
+      </div>
+
+      <p class="pt-3.5 pb-4 text-gray-dark text-lg font-bold">
+        田中 太郎さん&ensp;(80)
+      </p>
+
+      <p class="pb-0.5 text-[13px] text-gray-base font-bold">
+        面談希望日時
+      </p>
+      <p class="text-gray-dark">
+        12月31日(土)&nbsp;10:00〜12:00
+      </p>
+
+      <p class="pt-3 text-[13px] text-gray-base font-bold">
+        連絡先電話番号
+      </p>
+      <p class="pt-0.5 text-orange">
+        000-0000-0000
+      </p>
+
+      <AButtonSubmit
+        inner-text="連絡済みにする"
+        user-type="manager"
+        class="h-[40px] text-[14px] sm:text-sm md:text-sm mt-4"
+        @click="contactSubmit"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const contact = ref('未連絡')
+const textColor = ref('')
+
+const contactSubmit = () => {
+  contact.value = '連絡済み'
+  textColor.value = 'textColor'
+}
+</script>
+
+<style scoped lang="scss">
+.textColor {
+    @apply text-gray-base bg-gray-lighter
+}
+</style>

--- a/components/organisms/OReserveList.vue
+++ b/components/organisms/OReserveList.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="">
+    <ul class="grid gap-4 md:grid-cols-2">
+      <li
+        v-for="i in 6"
+        :key="i"
+        class="block m-auto w-full max-w-[400px] bg-white rounded shadow-[0_1px_6px_0_rgba(0,0,0,0.1)]"
+      >
+        <OReserveCard />
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/pages/manager/auth/reserves/index.vue
+++ b/pages/manager/auth/reserves/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="w-[355px] md:w-[730px] m-auto">
+    <ATitle ttl-text="予約状況確認" class="my-4" />
+    <OReserveList class="mb-[61px]" />
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
     extend: {
       colors: {
         pink: '#F06364',
+        babypink: '#F0636433',
         orange: '#F09C3C',
         lightGreen: '#a9f0d129',
         gray: {


### PR DESCRIPTION
予約状況確認画面のフロント実装が終了しました。

<img width="650" alt="スクリーンショット 2022-11-25 19 54 17" src="https://user-images.githubusercontent.com/70462212/203978349-54999e39-ce44-4fc2-ac39-2eb7cc2f03ef.png">

![ダウンロード (1)](https://user-images.githubusercontent.com/70462212/203978691-eed7d050-6d74-4a59-8314-4e14a35fba24.png)
