### PR TITLE
Add:スタッフ情報画面の追加

### DIFF
--- a/components/molecules/MButtonWithPlus.vue
+++ b/components/molecules/MButtonWithPlus.vue
@@ -4,7 +4,7 @@
     class="block text-center font-bold border rounded transition-opacity hover:opacity-80"
   >
     <APlus class="plus_wrap">
-      利用者を追加する
+      <slot />
     </APlus>
   </NuxtLink>
 </template>

--- a/components/organisms/OStaffsInfo.vue
+++ b/components/organisms/OStaffsInfo.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <!-- タイトル -->
+    <ATitle ttl-text="スタッフ情報" class="mb-4" />
+
+    <!-- スタッフ情報一覧 -->
+    <OStaffsInfoList class="mb-8 w-full sm:mb-[38px]" />
+
+    <!-- スタッフ追加ボタン -->
+    <MButtonWithPlus class="p-2.5 w-full m-auto max-w-[400px] bg-white text-base text-orange sm:p-3.5 sm:max-w-none">
+      スタッフを追加する
+    </MButtonWithPlus>
+  </div>
+</template>

--- a/components/organisms/OStaffsInfoItem.vue
+++ b/components/organisms/OStaffsInfoItem.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="p-3">
+    <div class="w-full flex mb-3">
+      <!-- スタッフイメージ画像（円形） -->
+      <AImageRound
+        src="https://placehold.jp/a6deda/ffffff/150x150.png"
+        alt="スタッフイメージ画像"
+        class="mr-3 w-20 h-20"
+      />
+      <div>
+        <!-- 氏名 -->
+        <h3 class="text-sm text-gray-dark font-bold">
+          田中太郎
+        </h3>
+        <!-- ひらがな -->
+        <p class="mb-2 text-[10px] text-gray-base">
+          たなかたろう
+        </p>
+        <!-- スタッフ説明テキスト -->
+        <p class="mb-2 text-xs text-gray-base">
+          スタッフ説明テキストが入ります。スタッフ説明テキストが入ります。
+        </p>
+      </div>
+    </div>
+    <div class="flex justify-between gap-2">
+      <!-- スタッフ削除ボタン -->
+      <AButton
+        inner-text="削除"
+        class="text-orange hover:bg-white min-w-[115px]"
+      />
+      <!-- スタッフ情報編集ボタン -->
+      <AButton inner-text="編集する" user-type="manager" class="w-full" />
+    </div>
+  </div>
+</template>
+

--- a/components/organisms/OStaffsInfoList.vue
+++ b/components/organisms/OStaffsInfoList.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <ul class="grid gap-x-3 gap-y-6 sm:grid-cols-2">
+      <li
+        v-for="i in 6"
+        :key="i"
+        class="block m-auto w-full max-w-[400px] bg-white rounded shadow-[0_1px_6px_0_rgba(0,0,0,0.1)]"
+      >
+        <!-- スタッフ情報画面の各アイテム -->
+        <OStaffsInfoItem />
+      </li>
+    </ul>
+  </div>
+</template>

--- a/components/organisms/OUserInfo.vue
+++ b/components/organisms/OUserInfo.vue
@@ -7,6 +7,8 @@
     <OUserInfoList class="mb-8 w-full sm:mb-[38px]" />
 
     <!-- 利用者追加ボタン -->
-    <MButtonWithPlus class="p-2.5 w-full m-auto max-w-[400px] bg-white text-base text-orange sm:p-3.5 sm:max-w-none" />
+    <MButtonWithPlus class="p-2.5 w-full m-auto max-w-[400px] bg-white text-base text-orange sm:p-3.5 sm:max-w-none">
+      利用者を追加する
+    </MButtonWithPlus>
   </div>
 </template>

--- a/pages/manager/auth/staffs/index.vue
+++ b/pages/manager/auth/staffs/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <OStaffsInfo class="wrapper" />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.wrapper {
+  @apply block pt-4 px-2.5 mb-[52px] w-full max-w-[722px] sm:pt-10 sm:mb-20 md:mx-auto;
+}
+</style>


### PR DESCRIPTION
## 変更の概要
スタッフ情報画面の実装（レスポンシブデザインまで）が完了しました。

## 期日
* 2022/12/11(日)

## 対象チケット
[チケット](https://github.com/rtkjm22/homeCareNavi_2nd_FRONT/issues/21)

## やったこと

* [x] スタッフ情報画面の追加（レスポンシブ対応）

## 課題

* コンポーネントの分け方についてアトミックデザインを参考に行っているが、正しく分けられているかどうか？
* 他に分割できる部分はあるかどうか？

## 備考

特になし

## 実装画面
### PC画面
![localhost_8080_manager_auth_staffs_](https://user-images.githubusercontent.com/74517286/206828071-1391abbc-3638-4746-8121-a909d3807a95.png)



### TAB画面
![localhost_8080_manager_auth_staffs_(iPad Mini)](https://user-images.githubusercontent.com/74517286/206828078-c8d8c5a3-073d-4653-a13d-3ed84c8894c9.png)


### SP画面
![localhost_8080_manager_auth_staffs_(iPhone SE)](https://user-images.githubusercontent.com/74517286/206828081-4e2aefc4-9bde-4c30-ab2c-1650a6cb29c0.png)

