### PR TITLE
ヘッダー・フッターの改修

### DIFF
--- a/components/organisms/OFooter.vue
+++ b/components/organisms/OFooter.vue
@@ -23,7 +23,7 @@
           >
             <nav>
               <ul class="flex ">
-                <li v-for="link in links" :key="link.text" class="linkItem">
+                <li v-for="link in links" :key="link.text" class="linkItem" :class="roleColor">
                   <NuxtLink :to="link.to">
                     {{ link.text }}
                   </NuxtLink>
@@ -38,6 +38,21 @@
 </template>
 
 <script setup lang="ts">
+type Props = {
+  role?: 'client' | 'manager'
+}
+
+const props = withDefaults(
+  defineProps<Props>(),
+  { role: 'client' }
+)
+
+const roleColor = computed(() => {
+  if (props.role === 'manager') {
+    return `linkItem-${props.role}`
+  }
+})
+
 const links = [
   {
     text: 'プライバシーポリシー',
@@ -57,6 +72,9 @@ const links = [
 <style scoped lang="scss">
 .linkItem {
   @apply text-[11px] text-pink whitespace-nowrap;
+  &-manager {
+    @apply text-orange;
+  }
 }
 .linkItem:not(:last-of-type) {
   @apply mr-5;

--- a/components/organisms/OHeader.vue
+++ b/components/organisms/OHeader.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="border-t-2 border-t-pink shadow-sm">
+  <div class="border-t-2 shadow-sm" :class="borderTopColor">
     <div class="relative bg-white">
       <div class="max-w-7xl mx-auto px-4 sm:px-6">
         <div
           class="flex justify-between items-center pt-4 pb-3 md:justify-start md:space-x-10"
         >
           <!-- ヘッダー画像 -->
-          <div class="flex justify-start lg:w-0 lg:flex-1">
+          <div class="flex justify-start lg:w-0 lg:flex-1 md:hidden lg:flex">
             <NuxtLink to="/">
               <img
                 class="h-8 w-auto sm:h-8"
@@ -14,6 +14,10 @@
                 alt=""
               />
             </NuxtLink>
+            <!-- ロールがマネージャーのときのみ出現する「Staff」タグ -->
+            <div v-if="userType === 'manager'" class="relative block ml-2">
+              <span class="absolute top-[6px] px-2 pt-[1px] pb-[1.5px] rounded-sm text-[11px] font-medium bg-orange text-white">Staff</span>
+            </div>
           </div>
 
           <!-- メニュー部（PC） -->
@@ -149,17 +153,18 @@ const links = computed<Link[] | undefined>(() => {
       return [
         { innerText: '閲覧履歴', to: '/' },
         { innerText: 'ブックマーク', to: '/' },
-        { innerText: '予約状況確認', to: '/' },
+        { innerText: '予約状況確認', to: '/client/auth/reserves' },
         { innerText: 'レビュー履歴', to: '/' },
         { innerText: '登録情報変更', to: '/client/auth/profile' }
       ]
     case 'manager':
       return [
-        { innerText: '事業所情報編集', to: '/' },
-        { innerText: 'スタッフ情報', to: '/' },
+        { innerText: '事業所情報編集', to: '/manager/auth/profile/edit' },
+        { innerText: '施設概要編集', to: '/manager/auth/profile/edit_inst' },
+        { innerText: 'スタッフ情報', to: '/manager/auth/staffs' },
         { innerText: 'お礼一覧', to: '/' },
-        { innerText: '予約状況確認', to: '/' },
-        { innerText: '利用者情報管理', to: '/' }
+        { innerText: '予約状況確認', to: '/manager/auth/reserves' },
+        { innerText: '利用者情報管理', to: '/manager/auth/clients' }
       ]
   }
 })
@@ -177,6 +182,15 @@ const logout = async () => {
   await navigateTo('/client/login')
   showAlert('ログアウトしました', 'success')
 }
+
+/** ヘッダー上部のボーダー */
+const borderTopColor = computed(() => {
+  if (props.userType === "manager") {
+    return `border-t-orange`
+  } else {
+    return `border-t-pink`
+  }
+})
 </script>
 
 <style scoped lang="scss">

--- a/layouts/manager.vue
+++ b/layouts/manager.vue
@@ -3,7 +3,7 @@
     <OHeader user-type="manager" />
     <AAlert />
     <slot />
-    <OFooter class="footer" />
+    <OFooter class="footer" role="manager" />
   </div>
 </template>
 


### PR DESCRIPTION
## 変更の概要
ヘッダー・フッターの改修が完了しました。

## 期日
* 2022/12/21(日)

## 対象チケット
[チケット](https://github.com/rtkjm22/homeCareNavi_2nd_FRONT/issues/54)

## やったこと

①ヘッダー及びフッターのリンクつなぎこみ
②各画面へのヘッダー・フッターの反映
③チーム内でレビューをしてもらい、チームの合意を得る

## 課題
特になし

## 備考
特になし
